### PR TITLE
Fix svg image alignment and scale

### DIFF
--- a/fix_pdf_tex.py
+++ b/fix_pdf_tex.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+re_include_graphics = re.compile(
+        r'\\includegraphics\[width=\\unitlength,page=(\d+)\]')
+re_end_picture = re.compile(r'\\end\{picture\}')
+
+inside = False
+num_pages = int(sys.argv[1])
+for line in sys.stdin:
+    if not inside:
+        m = re_include_graphics.search(line)
+        if m and int(m.group(1)) > num_pages:
+            inside = True
+            sys.stderr.write('skip: %s' % line)
+            continue
+    else:
+        if re_end_picture.search(line):
+            inside = False
+        else:
+            sys.stderr.write('skip: %s' % line)
+            continue
+    print(line)
+

--- a/setup.sh
+++ b/setup.sh
@@ -6,8 +6,13 @@ cp -r ./book/second-edition/src/img ./
 for f in ./img/*.svg
 do
   if [[ $f =~ \./img/(.*)\.svg ]]; then
-    inkscape -z -D --file=`pwd`/img/${BASH_REMATCH[1]}.svg --export-pdf=`pwd`/${BASH_REMATCH[1]}.pdf
-    # inkscape -z -D --file=`pwd`/${BASH_REMATCH[1]}.pdf --export-latex=`pwd`/${BASH_REMATCH[1]}.pdf_tex
+    SVG=`pwd`/img/${BASH_REMATCH[1]}.svg
+    PDF=`pwd`/${BASH_REMATCH[1]}.pdf
+    PDFTEX=`pwd`/${BASH_REMATCH[1]}.pdf_tex
+    inkscape -z -D --file="$SVG" --export-pdf="$PDF" --export-latex
+    PAGES=$(egrep -a '/Type /Page\b' "$PDF" | wc -l | tr -d ' ')
+    python fix_pdf_tex.py "$PAGES" < "$PDFTEX" > "$PDFTEX.tmp"
+    mv "$PDFTEX.tmp" "$PDFTEX"
   fi
 done
 


### PR DESCRIPTION
SVG 画像に拡大率や中寄せが指定されている場合に対応しました。
[ひとつの SVG が 1 ページ全部占有する問題](https://github.com/y-yu/trpl-2nd-pdf/pull/12#issuecomment-384725953)も解消しました。

Inkscape 0.92.2 が生成する .pdf_tex が存在しないページを参照しているので、
その箇所を fix_pdf_tex.py で 削除してから `\input{foo.pdf_tex}` で SVG を貼るようにしています。