### PR TITLE
Fix foreword position

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ all : book.pdf
 clean :
 	latexmk -C
 
-book.pdf : book.tex
+book.pdf : book.tex body.tex
 	latexmk -pdf book.tex

--- a/body.py
+++ b/body.py
@@ -5,12 +5,13 @@ import sys, re
 
 if __name__ == "__main__":
     print('\\frontmatter')
+    print('\\input{./target/foreword.tex}')
     print('\\tableofcontents')
     print('\\mainmatter')
     print('\\setcounter{secnumdepth}{3}')
     
     for line in sys.stdin:
         r = re.search(r'\[.*\]\((.*)\.md\)$', line)
-        if r is not None:
+        if r is not None and not r.group(1) == 'foreword':
             src = r.group(1)
             print('\\input{./target/' + src + '.tex}')


### PR DESCRIPTION
- 「まえがき」を目次の前に移動させ、章番号を消した
- これにより原著との章番号のずれが少々解決する => #10 