### PR TITLE
Adjust listings styling

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -3,7 +3,7 @@
 
 import os
 import sys, base64, re
-from pandocfilters import toJSONFilter, CodeBlock, RawBlock, Str, RawInline
+from pandocfilters import toJSONFilter, CodeBlock, RawBlock, Str, RawInline, Para
 
 reload(sys)  
 sys.setdefaultencoding('utf8')
@@ -92,6 +92,10 @@ def filter(key, value, fmt, meta):
                 if width:
                     width = float(width.group(1)) / 100
                 return mkFigure(src, align=cls, scale=width)
+            elif fmt == 'html' and 'class="caption"' in content:
+                return [Para(value), RawBlock('latex', r'\vspace{1em}')]
+            elif fmt == 'html' and 'class="filename"' in content:
+                return [RawBlock('latex', r'\vspace{1em}'), Para(value)]
 
 if __name__ == "__main__":
     toJSONFilter(filter)

--- a/listings.tex
+++ b/listings.tex
@@ -10,19 +10,19 @@
 
 \lstset{
   basicstyle=\listingfont\footnotesize,
-  frame=single,
-  breaklines=true
-  numbersep=5pt,
+  frame=none,
+  breaklines=true,
   linewidth=\textwidth,
   xleftmargin=15pt,
-  xrightmargin=15pt
+  xrightmargin=15pt,
+  aboveskip=1em,
+  belowskip=0.5em
 }
 
 \lstdefinestyle{rust}{
   breakatwhitespace=false,
   language=rust,
-  numbers=left,
-  numberstyle=\listingfont\scriptsize\color{gray},
+  numbers=none,
   captionpos=b,
   commentstyle=\listingfont\color{dkgreen},
   extendedchars=true,

--- a/listings.tex
+++ b/listings.tex
@@ -2,6 +2,7 @@
 \definecolor{dkgreen}{rgb}{0,0.6,0}
 \definecolor{gray}{rgb}{0.5,0.5,0.5}
 \definecolor{mauve}{rgb}{0.58,0,0.82}
+\definecolor{smoke}{RGB}{245,245,245}
 
 \makeatletter
 \lst@CCPutMacro\lst@ProcessOther {"2D}{\lst@ttfamily{-{}}{-{}}}
@@ -16,7 +17,8 @@
   xleftmargin=15pt,
   xrightmargin=15pt,
   aboveskip=1em,
-  belowskip=0.5em
+  belowskip=0.5em,
+  backgroundcolor=\color{smoke}
 }
 
 \lstdefinestyle{rust}{


### PR DESCRIPTION
Fix #4 

リスティングの見た目を調整しました：

* 上下のマージンの増加の追加と（ファイル名がリスティングの上に来る場合とキャプションが下に来る場合にも対応）
* 行番号と枠線の削除

後者については個人的な好みによるところが強いので問題あれば言ってください。

----

こちらがマージン調整だけしたもので、


![screen shot 2018-05-04 at 08 30 24](https://user-images.githubusercontent.com/18096192/39607783-f50c0200-4f77-11e8-8485-455ef368487d.png)

----

こちらがマージン調整に加えて行番号と枠線を削除したものです：


![screen shot 2018-05-04 at 08 30 59](https://user-images.githubusercontent.com/18096192/39607787-fa4a61e4-4f77-11e8-9c63-528e16de3300.png)

