### PR TITLE
Add internal margin to listings

### DIFF
--- a/listings.tex
+++ b/listings.tex
@@ -11,11 +11,16 @@
 
 \lstset{
   basicstyle=\listingfont\footnotesize,
-  frame=none,
+  frame=tb,
+  framerule=0pt,
   breaklines=true,
   linewidth=\textwidth,
   xleftmargin=15pt,
   xrightmargin=15pt,
+  framexleftmargin=5pt,
+  framexrightmargin=5pt,
+  framextopmargin=2pt,
+  framexbottommargin=2pt,
   aboveskip=1em,
   belowskip=0.5em,
   backgroundcolor=\color{smoke}


### PR DESCRIPTION
Fix #26

リスティングの（見えない）枠の内側にマージンを入れました。見た目はこんな感じです：

![screen shot](https://user-images.githubusercontent.com/18096192/39667618-5683f474-50f5-11e8-9fb4-76cfbb42aae3.png)

`frame=none` を指定すると framextopmargin や framexbottommargin が当たらないようだったので、
次のリンクを参考にして `frame=tb` と `framerule=0pt` を設定しました。

https://tex.stackexchange.com/questions/167833/

なお、上の画像でリスティングとキャプション（リスト4-6: 借用した値を...）の間がやけに広くなってますが、これは私には直すの難しそうなので別途 issue にあげたいと思います。