### PR TITLE
Update entrypoint in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,4 +109,4 @@ VOLUME ["/workdir"]
 
 WORKDIR /workdir
 
-ENTRYPOINT ["/bin/bash", "-c", "./setup.sh && make"]
+ENTRYPOINT ["/bin/bash", "-c", "./setup.sh && USE_SOURCEHAN=true make"]


### PR DESCRIPTION
- Dockerでコンパイルする際に源ノ角ゴシック・源ノ明朝を使うようにした