### PR TITLE
Fix spacing after inline code

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -95,8 +95,6 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
-\providecommand{\passthrough}[1]{#1}
-
 % ヘッダーの長さを調整するワークアラウンド
 \setlength{\fullwidth}{\textwidth}
 

--- a/listings.tex
+++ b/listings.tex
@@ -4,6 +4,11 @@
 \definecolor{mauve}{rgb}{0.58,0,0.82}
 \definecolor{smoke}{RGB}{245,245,245}
 
+% \lstinlineの後にはなぜか自動でスペースが入らないので、
+% 手でスペースを入れるための処理を追加する
+% （\passthroughコマンドはPandocが自動で追加する）
+\providecommand{\passthrough}[1]{#1\hskip\ltjgetparameter{xkanjiskip}}
+
 \makeatletter
 \lst@CCPutMacro\lst@ProcessOther {"2D}{\lst@ttfamily{-{}}{-{}}}
 \@empty\z@\@empty


### PR DESCRIPTION
Fix #35.

このようにインラインコードの後にもスペースが入るようにしました。

![image](https://user-images.githubusercontent.com/612043/39954884-14886390-5602-11e8-9880-ffa4fd293939.png)

Thanks to Kitagawa!